### PR TITLE
Swapping class-based instantiation with Objective-C style alloc.init …

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,43 +14,38 @@ npm i nativescript-sound-kak
 
 ## Usage
 
-To use this plugin you must first require() it:
+To use this plugin you must first require or import it:
 
 ```js
-var sound = require("nativescript-sound");
+//CommonJs
+const sound = require("nativescript-sound-kak");
+
+//ES6 Import
+import sound from "nativescript-sound-kak";
 ```
 
-### create and play
+### Create and Play
 
 It's important to preload the audio file into the **sound** module before playing it; there is a delay during creation due to the audio being processed:
 
 ```js
-var tada = sound.create("~/sounds/tada.mp3"); // preload the audio file
+const tada = sound.create("./path/to/file.mp3"); // preload the audio file
 
 // play the sound (i.e. tap event handler)
 tada.play();
 ```
 
-A good way to do this is to create a sound collection:
+You may wish to check that the file actually exists:
 
 ```js
-sounds = {
-	"Tada": sound.create("~/sounds/tada.mp3"),
-	"Boo": sound.create("~/sounds/boo.mp3"),
-	// ...
-};
-```
+import * as fs from "tns-core-modules/file-system";
+import * as Sound from 'nativescript-sound-kak';
 
-If you wish to play a sound due to a button being tapped, leverage the following code (where `name` refers to the name of the audio file to be played):
-
-```js
-this.playButtonPressed = function(name) {
-	if (app.android) {
-		sounds[name].play();
-	} else {
-		var soundFile = sound.create("~/sounds/" + name + ".mp3");
-		soundFile.play();
-	}
+// currentApp().path leads to your app folder in the project
+const pathToBeep = fs.path.join(fs.knownFolders.currentApp().path, '/assets/sounds/beep.mp3');
+let beepSound;
+if (fs.File.exists(pathToBeep)) {
+	beepSound = Sound.create(pathToBeep);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 Play a sound in your NativeScript app.
 
+This project was originally programmed by John Bristowe. However when this plugin is used in a project installed on a phone with iOS 13.2, the entire application would crash. This fork is a modified version of the original project that solves the instantiation crash issue that I encountered. The rest of the project remained intact.
+
 ## Installation
 
 Run the following command from the root of your project:
 
 ```
-npm-install (to be determined)
+npm i nativescript-sound-kak
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use this plugin you must first require or import it:
 const Sound = require("nativescript-sound-kak");
 
 //ES6 Import
-import Sound from "nativescript-sound-kak";
+import * as Sound from "nativescript-sound-kak";
 ```
 
 ### Create and Play
@@ -29,7 +29,7 @@ import Sound from "nativescript-sound-kak";
 It's important to preload the audio file into the **sound** module before playing it; there is a delay during creation due to the audio being processed:
 
 ```js
-const beep = sound.create("./path/to/file.mp3"); // preload the audio file
+const beep = Sound.create("./path/to/file.mp3"); // preload the audio file
 
 // play the sound (i.e. tap event handler)
 beep.play();
@@ -59,4 +59,20 @@ beep.stop();
 
 ```js
 beep.reset();
+```
+
+### Background Playback
+
+In iOS, the default playback method will silence all background sounds. You can define whether the audio playback in the app silences background audio (i.e. the Music app) or if it play concurrently.
+
+```js
+import * as Sound from 'nativescript-sound-kak';
+// Sets the audio playback to background, i.e. allows it to play at the same time as other background audio.
+Sound.setBackground(true);
+```
+
+```js
+import * as Sound from 'nativescript-sound-kak';
+// Turns off background playback. When the Sound object is created, background audio will be silenced
+Sound.setBackground(false);
 ```

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ import Sound from "nativescript-sound-kak";
 It's important to preload the audio file into the **sound** module before playing it; there is a delay during creation due to the audio being processed:
 
 ```js
-const tada = sound.create("./path/to/file.mp3"); // preload the audio file
+const beep = sound.create("./path/to/file.mp3"); // preload the audio file
 
 // play the sound (i.e. tap event handler)
-tada.play();
+beep.play();
 ```
 
 You may wish to check that the file actually exists:
@@ -43,20 +43,20 @@ import * as Sound from 'nativescript-sound-kak';
 
 // currentApp().path leads to your app folder in the project
 const pathToBeep = fs.path.join(fs.knownFolders.currentApp().path, '/assets/sounds/beep.mp3');
-let beepSound;
+let beep;
 if (fs.File.exists(pathToBeep)) {
-	beepSound = Sound.create(pathToBeep);
+	beep = Sound.create(pathToBeep);
 }
 ```
 
 ### stop
 
 ```js
-tada.stop();
+beep.stop();
 ```
 
 ### reset
 
 ```js
-tada.reset();
+beep.reset();
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Play a sound in your NativeScript app.
 Run the following command from the root of your project:
 
 ```
-tns plugin add nativescript-sound
+npm-install (to be determined)
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ To use this plugin you must first require or import it:
 
 ```js
 //CommonJs
-const sound = require("nativescript-sound-kak");
+const Sound = require("nativescript-sound-kak");
 
 //ES6 Import
-import sound from "nativescript-sound-kak";
+import Sound from "nativescript-sound-kak";
 ```
 
 ### Create and Play

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nativescript-sound",
+  "name": "nativescript-sound-kak",
   "version": "1.0.6",
   "description": "Play a sound in your NativeScript app",
   "main": "sound",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-sound-kak",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Play a sound in your NativeScript app",
   "main": "sound",
   "nativescript": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-sound-kak",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Play a sound in your NativeScript app",
   "main": "sound",
   "nativescript": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "nativescript-sound",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Play a sound in your NativeScript app",
-  "main": "sound.js",
+  "main": "sound",
   "nativescript": {
     "platforms": {
       "ios": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-sound-kak",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Play a sound in your NativeScript app",
   "main": "sound",
   "nativescript": {
@@ -18,12 +18,7 @@
     "Sound",
     "Audio"
   ],
-  "author": "John Bristowe <john@bristowe.com> (https://github.com/jbristowe)",
-  "contributors": [{
-    "name": "Mathew Thompson",
-    "email": "met@methompson.com",
-    "url": "https://github.com/methompson"
-  }],
+  "author": "Mathew Thompson <met@methompson.com> (https://github.com/methompson)",
   "license": "MIT",
   "bugs": "https://github.com/methompson/nativescript-sound/issues",
   "homepage": "https://github.com/methompson/nativescript-sound"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-sound",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Play a sound in your NativeScript app",
   "main": "sound.js",
   "nativescript": {
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jbristowe/nativescript-sound.git"
+    "url": "https://github.com/methompson/nativescript-sound.git"
   },
   "keywords": [
     "NativeScript",
@@ -19,7 +19,12 @@
     "Audio"
   ],
   "author": "John Bristowe <john@bristowe.com> (https://github.com/jbristowe)",
+  "contributors": [{
+    "name": "Mathew Thompson",
+    "email": "met@methompson.com",
+    "url": "https://github.com/methompson"
+  }],
   "license": "MIT",
-  "bugs": "https://github.com/jbristowe/nativescript-sound/issues",
-  "homepage": "https://github.com/jbristowe/nativescript-sound"
+  "bugs": "https://github.com/methompson/nativescript-sound/issues",
+  "homepage": "https://github.com/methompson/nativescript-sound"
 }

--- a/sound-common.js
+++ b/sound-common.js
@@ -1,24 +1,20 @@
-var fs = require("file-system");
-var types = require("utils/types");
+import * as fs from 'tns-core-modules/file-system';
 
-var Sound = (function () {
-    function Sound() {
-        if (arguments.length === 1) {
-            var arg = arguments[0];
-            var path = types.isString(arg) ? arg.trim() : "";
+class Sound {
+    constructor(path_arg){
+        let path = typeof path_arg === typeof "string" ? path_arg.trim() : '';
 
-            if (path.indexOf("~/") === 0) {
-                path = fs.path.join(fs.knownFolders.currentApp().path, path.replace("~/", ""));
-            }
-            
-            if (!fs.File.exists(path)) {
-                console.error("Sound not initialized; file not found.");
-                return;
-            }
-            
-            this._path = path;
+        if (path.indexOf("~/") === 0) {
+            path = fs.path.join(fs.knownFolders.currentApp().path, path.replace("~/", ""));
         }
+
+        if (!fs.File.exists(path)) {
+            console.error("Sound not initialized; file not found.");
+            return;
+        }
+
+        this._path = path;
     }
-    return Sound;
-})();
-exports.Sound = Sound;
+};
+
+export default Sound;

--- a/sound-common.js
+++ b/sound-common.js
@@ -1,20 +1,20 @@
 import * as fs from 'tns-core-modules/file-system';
 
 class Sound {
-    constructor(path_arg){
-        let path = typeof path_arg === typeof "string" ? path_arg.trim() : '';
+  constructor(path_arg) {
+    let path = typeof path_arg === typeof "string" ? path_arg.trim() : '';
 
-        if (path.indexOf("~/") === 0) {
-            path = fs.path.join(fs.knownFolders.currentApp().path, path.replace("~/", ""));
-        }
-
-        if (!fs.File.exists(path)) {
-            console.error("Sound not initialized; file not found.");
-            return;
-        }
-
-        this._path = path;
+    if (path.indexOf("~/") === 0) {
+      path = fs.path.join(fs.knownFolders.currentApp().path, path.replace("~/", ""));
     }
+
+    if (!fs.File.exists(path)) {
+      console.error("Sound not initialized; file not found.");
+      return;
+    }
+
+    this._path = path;
+  }
 };
 
 export default Sound;

--- a/sound-common.js
+++ b/sound-common.js
@@ -15,6 +15,14 @@ class Sound {
 
     this._path = path;
   }
-};
+
+  play() {}
+
+  stop() {}
+
+  reset() {}
+
+  setBackground() {}
+}
 
 export default Sound;

--- a/sound.android.js
+++ b/sound.android.js
@@ -1,29 +1,29 @@
 import SoundCommon from './sound-common';
 
 class Sound extends SoundCommon {
-    constructor(path_arg){
-        super(path_arg);
+  constructor(path_arg) {
+    super(path_arg);
 
-        this._player = new android.media.SoundPool(1, android.media.AudioManager.STREAM_MUSIC, 0);
-        this._soundId = this._player.load(this._path, 1);
-    }
+    this._player = new android.media.SoundPool(1, android.media.AudioManager.STREAM_MUSIC, 0);
+    this._soundId = this._player.load(this._path, 1);
+  }
 
-    play(){
-        this._player.play(this._soundId, 1.0, 1.0, 1, 0, 1.0);
-    };
+  play() {
+    this._player.play(this._soundId, 1.0, 1.0, 1, 0, 1.0);
+  };
 
-    stop(){
-        this._player.stop(this._soundId);
-    };
+  stop() {
+    this._player.stop(this._soundId);
+  };
 
-    // Does nothing. This method is defined and may be used, so it has to be defined here.
-    reset(){};
+  // Does nothing. This method is defined and may be used, so it has to be defined here.
+  reset() {};
 };
 
 const create = (path) => {
-    return new Sound(path);
+  return new Sound(path);
 };
 
 export {
-    create,
+  create,
 };

--- a/sound.android.js
+++ b/sound.android.js
@@ -10,15 +10,15 @@ class Sound extends SoundCommon {
 
   play() {
     this._player.play(this._soundId, 1.0, 1.0, 1, 0, 1.0);
-  };
+  }
 
   stop() {
     this._player.stop(this._soundId);
-  };
+  }
+}
 
-  // Does nothing. This method is defined and may be used, so it has to be defined here.
-  reset() {};
-};
+// Doing nothing right now in Android
+const setBackground = (background) => {};
 
 const create = (path) => {
   return new Sound(path);
@@ -26,4 +26,5 @@ const create = (path) => {
 
 export {
   create,
+  setBackground,
 };

--- a/sound.android.js
+++ b/sound.android.js
@@ -1,25 +1,29 @@
-var common = require("./sound-common");
+import SoundCommon from './sound-common';
 
-var Sound = (function (_super) {
-    __extends(Sound, _super);
-    function Sound() {
-        _super.apply(this, arguments);
+class Sound extends SoundCommon {
+    constructor(path_arg){
+        super(path_arg);
 
         this._player = new android.media.SoundPool(1, android.media.AudioManager.STREAM_MUSIC, 0);
         this._soundId = this._player.load(this._path, 1);
     }
-    Sound.prototype.play = function () {
+
+    play(){
         this._player.play(this._soundId, 1.0, 1.0, 1, 0, 1.0);
     };
-    Sound.prototype.stop = function () {
+
+    stop(){
         this._player.stop(this._soundId);
     };
-    Sound.prototype.reset = function () {
-    };
-    return Sound;
-})(common.Sound);
-exports.Sound = Sound;
 
-exports.create = function(path) {
+    // Does nothing. This method is defined and may be used, so it has to be defined here.
+    reset(){};
+};
+
+const create = (path) => {
     return new Sound(path);
+};
+
+export {
+    create,
 };

--- a/sound.ios.js
+++ b/sound.ios.js
@@ -5,9 +5,8 @@ var Sound = (function (_super) {
     function Sound() {
         _super.apply(this, arguments);
         
-        this._url = NSURL.fileURLWithPath(this._path); 
-        this._player = new AVAudioPlayer();
-        this._player.initWithContentsOfURLError(this._url);            
+        this._url = NSURL.fileURLWithPath(this._path);
+        this._player = AVAudioPlayer.alloc().initWithContentsOfURLError(this._url);            
         this._player.prepareToPlay();
     }
     Sound.prototype.play = function () {

--- a/sound.ios.js
+++ b/sound.ios.js
@@ -1,7 +1,7 @@
 import SoundCommon from './sound-common';
 
 class Sound extends SoundCommon {
-  constructor(path_arg) {
+  constructor(path_arg, options) {
     super(path_arg);
 
     this._url = NSURL.fileURLWithPath(this._path);
@@ -11,23 +11,47 @@ class Sound extends SoundCommon {
 
   play() {
     this._player.play();
-  };
+  }
 
   stop() {
     this._player.stop();
-  };
+  }
 
   reset() {
     this._player.stop();
     this._player.prepareToPlay();
     this._player.currentTime = 0;
-  };
+  }
+}
+
+function isBoolean(qBool) {
+  return typeof qBool === typeof true;
+}
+
+const setBackground = (background) => {
+  if (!isBoolean(background)) {
+    return;
+  }
+
+  let cat;
+
+  if (background) {
+    cat = AVAudioSessionCategoryAmbient;
+  } else {
+    cat = AVAudioSessionCategoryPlayback;
+  }
+
+  const audioSession = AVAudioSession.sharedInstance();
+  audioSession.setCategoryError(cat, null);
 };
 
 const create = (path) => {
-  return new Sound(path);
+  const s = new Sound(path);
+
+  return s;
 };
 
 export {
   create,
+  setBackground,
 };

--- a/sound.ios.js
+++ b/sound.ios.js
@@ -1,29 +1,33 @@
-var common = require("./sound-common");
+import SoundCommon from './sound-common';
 
-var Sound = (function (_super) {
-    __extends(Sound, _super);
-    function Sound() {
-        _super.apply(this, arguments);
-        
+class Sound extends SoundCommon {
+    constructor(path_arg){
+        super(path_arg);
+
         this._url = NSURL.fileURLWithPath(this._path);
-        this._player = AVAudioPlayer.alloc().initWithContentsOfURLError(this._url);
+        this._player = AVAudioPlayer.alloc().initWithContentsOfURLError(this._url);            
         this._player.prepareToPlay();
     }
-    Sound.prototype.play = function () {
+
+    play(){
         this._player.play();
     };
-    Sound.prototype.stop = function () {
+
+    stop(){
         this._player.stop();
     };
-    Sound.prototype.reset = function () {
+
+    reset(){
         this._player.stop();
         this._player.prepareToPlay();
         this._player.currentTime = 0;
     };
-    return Sound;
-})(common.Sound);
-exports.Sound = Sound;
+};
 
-exports.create = function(path) {
+const create = (path) => {
     return new Sound(path);
+};
+
+export {
+    create,
 };

--- a/sound.ios.js
+++ b/sound.ios.js
@@ -6,7 +6,7 @@ var Sound = (function (_super) {
         _super.apply(this, arguments);
         
         this._url = NSURL.fileURLWithPath(this._path);
-        this._player = AVAudioPlayer.alloc().initWithContentsOfURLError(this._url);            
+        this._player = AVAudioPlayer.alloc().initWithContentsOfURLError(this._url);
         this._player.prepareToPlay();
     }
     Sound.prototype.play = function () {

--- a/sound.ios.js
+++ b/sound.ios.js
@@ -1,33 +1,33 @@
 import SoundCommon from './sound-common';
 
 class Sound extends SoundCommon {
-    constructor(path_arg){
-        super(path_arg);
+  constructor(path_arg) {
+    super(path_arg);
 
-        this._url = NSURL.fileURLWithPath(this._path);
-        this._player = AVAudioPlayer.alloc().initWithContentsOfURLError(this._url);            
-        this._player.prepareToPlay();
-    }
+    this._url = NSURL.fileURLWithPath(this._path);
+    this._player = AVAudioPlayer.alloc().initWithContentsOfURLError(this._url);
+    this._player.prepareToPlay();
+  }
 
-    play(){
-        this._player.play();
-    };
+  play() {
+    this._player.play();
+  };
 
-    stop(){
-        this._player.stop();
-    };
+  stop() {
+    this._player.stop();
+  };
 
-    reset(){
-        this._player.stop();
-        this._player.prepareToPlay();
-        this._player.currentTime = 0;
-    };
+  reset() {
+    this._player.stop();
+    this._player.prepareToPlay();
+    this._player.currentTime = 0;
+  };
 };
 
 const create = (path) => {
-    return new Sound(path);
+  return new Sound(path);
 };
 
 export {
-    create,
+  create,
 };


### PR DESCRIPTION
…style instantiation. This solves a problem in iOS 13.2 wherein the use of `new AVAudioPlayer()` returns null, causing the entire app to crash. Using the Obective-C `alloc()` method solves this issue.